### PR TITLE
WIP: Convert to a recipe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "soulroll/silverstripe-reactstarter",
     "description": "A boilerplate for starting React SilverStripe projects faster",
-    "type": "silverstripe-boilerplate",
+    "type": "silverstripe-recipe",
     "license": "MIT License",
     "prefer-stable": true,
     "require": {


### PR DESCRIPTION
This allows the project to be installed as a standalone application or into an existing one, otherwise it appears in the vendor folder